### PR TITLE
update readme.md to add compatible python version

### DIFF
--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -18,6 +18,8 @@ Other tools for the PBAPI that have similar function include:
 This project is based around the [Python Google API client](https://developers.google.com/api-client-library/python/)
 for which you can find installation instructions [here](https://developers.google.com/api-client-library/python/start/installation).
 
+Note: This version of API is ONLY compatible with Python 2.7
+
 For all other dependencies, just run setup.py:
 
   python setup.py install


### PR DESCRIPTION
as this version of API is only compatible with python 2.7 and fires error when running it with python 3.6 so it is worth to mention this while setup the application